### PR TITLE
Affix bug on 0xCC Handler

### DIFF
--- a/OrionUO/Managers/PacketManager.cpp
+++ b/OrionUO/Managers/PacketManager.cpp
@@ -3550,7 +3550,8 @@ PACKET_HANDLER(DisplayClilocString)
 	//wstring args = ReadUnicodeStringLE(0);
 	wstring message = g_ClilocManager.ParseArgumentsToClilocString(cliloc, false, args);
 	//wstring message = ClilocManager->Cliloc(g_Language)->GetW(cliloc);
-
+	message = message + ToWString(affix);
+	
 	CGameObject *obj = g_World->FindWorldObject(serial);
 
 	if (/*type == ST_BROADCAST || type == ST_SYSTEM ||*/ serial == 0xFFFFFFFF || !serial || (ToLowerA(name) == "system" && obj == NULL))


### PR DESCRIPTION
There appears to be a bug where the affix is defined but not attached to anything.

This is creating problems with the 0xCC packet not showing quantities on objects like gold piles and bandages.